### PR TITLE
Fixed SetupCollFreqsFromLXCat stripping the units before passing into…

### DIFF
--- a/src/SwarmMC_include/SwarmMCLoaders.jl
+++ b/src/SwarmMC_include/SwarmMCLoaders.jl
@@ -280,11 +280,11 @@ end
 
     cfset = []
     for cs in set
-        eps = cs.energy * ustrip(u"J",1eV) / params.eps_unit
-        csval = cs.cs/params.len_unit^2
-        threshold = cs.threshold * ustrip(u"J",1eV) / params.eps_unit
+        eps = cs.energy * ustrip(u"J",1eV) #/ params.eps_unit
+        csval = cs.cs#/params.len_unit^2
+        threshold = cs.threshold * ustrip(u"J",1eV) #/ params.eps_unit
 
-        cf = CreateCollFreq(params, gas, ptype, cs.name, cs.colltype, GENCF_INTERP(eps, csval), threshold=threshold, temperature=temperature ; ionise_kwds...)
+        cf = CreateCollFreq(params, gas, ptype, cs.name, cs.colltype, GENCF_INTERP(eps, csval), threshold=threshold; ionise_kwds...)
         push!(cfset, cf)
     end
 

--- a/src/SwarmMC_include/SwarmMCLoaders.jl
+++ b/src/SwarmMC_include/SwarmMCLoaders.jl
@@ -280,9 +280,9 @@ end
 
     cfset = []
     for cs in set
-        eps = cs.energy * ustrip(u"J",1eV) #/ params.eps_unit
+        eps = cs.energy #* ustrip(u"J",1eV) #/ params.eps_unit
         csval = cs.cs#/params.len_unit^2
-        threshold = cs.threshold * ustrip(u"J",1eV) #/ params.eps_unit
+        threshold = cs.threshold #* ustrip(u"J",1eV) #/ params.eps_unit
 
         cf = CreateCollFreq(params, gas, ptype, cs.name, cs.colltype, GENCF_INTERP(eps, csval), threshold=threshold; ionise_kwds...)
         push!(cfset, cf)


### PR DESCRIPTION
… GENCF_INTERP
fixes #6  (I believe)

So using SetupCollFreqsFromLXCat stripps the units before passing into GENCF_INTERP - however GENCF_INTERP requires units of eV:

```julia
@xport struct GENCF_INTERP{T} <: GENCF_PARAMS
    x::Vector{Q(uE)}
    y::Vector{T}
    extrap
end
```

So I've taken the liberty of removing the ustrip functions plus a temperature that no long exists it appears. Seems to me just a bit of code leftover after changing GENCF_INTERP to require units of eV?

I've benchmarked the code against my code using Neon which works out well so I assume this should be all good.

However it's possible I've missunderstood something critical still :)